### PR TITLE
blast2lca gives X11 missing error

### DIFF
--- a/tools/blast2lca
+++ b/tools/blast2lca
@@ -39,6 +39,6 @@ else
 	classpath="$jars_dir/MEGAN.jar:../$jars_idr/MALT.jar:$jars_dir/data.jar:"
 fi
 
-java_flags="-server -Duser.language=en -Duser.region=US $vmOptions"
+java_flags="-server -Duser.language=en -Duser.region=US -Djava.awt.headless=true $vmOptions"
 
 $java $java_flags -cp "$classpath" megan.tools.Blast2LCA  $options


### PR DESCRIPTION
i get the following error when using blast2lca on my server (MEGAN CE 6.6.0)

```
Version   MEGAN Community Edition (version 6.6.0, built 24 Nov 2016)
Author(s) Daniel H. Huson
Copyright (C) 2016 Daniel H. Huson. This program comes with ABSOLUTELY NO WARRANTY.
Exception in thread "main" java.awt.AWTError: Can't connect to X11 window server using 'localhost:10.0' as the value of the DISPLAY variable.
        at sun.awt.X11GraphicsEnvironment.initDisplay(Native Method)
        at sun.awt.X11GraphicsEnvironment.access$200(X11GraphicsEnvironment.java:65)
        at sun.awt.X11GraphicsEnvironment$1.run(X11GraphicsEnvironment.java:115)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.awt.X11GraphicsEnvironment.<clinit>(X11GraphicsEnvironment.java:74)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:260)
        at java.awt.GraphicsEnvironment.createGE(GraphicsEnvironment.java:102)
        at java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment(GraphicsEnvironment.java:81)
        at sun.awt.X11.XToolkit.<clinit>(XToolkit.java:123)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:260)
        at java.awt.Toolkit$2.run(Toolkit.java:860)
        at java.awt.Toolkit$2.run(Toolkit.java:855)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.awt.Toolkit.getDefaultToolkit(Toolkit.java:854)
        at jloda.util.ResourceManager.getImageResource(ResourceManager.java:244)
        at jloda.util.ResourceManager.getIcon(ResourceManager.java:114)
        at megan.main.MeganProperties.initializeProperties(MeganProperties.java:97)
        at megan.tools.Blast2LCA.run(Blast2LCA.java:137)
        at megan.tools.Blast2LCA.main(Blast2LCA.java:61)
```

fixed it by modifying this line

```
java_flags="-server -Duser.language=en -Duser.region=US $vmOptions"
```

with 

` -Djava.awt.headless=true`